### PR TITLE
Add support for RenderPostProcessor + memory optimizations

### DIFF
--- a/clustering/src/main/java/com/huawei/clustering/Cluster.java
+++ b/clustering/src/main/java/com/huawei/clustering/Cluster.java
@@ -1,5 +1,7 @@
 package com.huawei.clustering;
 
+import com.huawei.hms.maps.model.LatLng;
+
 import androidx.annotation.NonNull;
 
 import java.util.List;
@@ -17,6 +19,8 @@ public class Cluster<T extends ClusterItem> {
     private final double south;
     private final double east;
 
+    private final LatLng latLng;
+
     Cluster(double latitude, double longitude, @NonNull List<T> items,
             double north, double west, double south, double east) {
         this.latitude = latitude;
@@ -26,6 +30,8 @@ public class Cluster<T extends ClusterItem> {
         this.west = west;
         this.south = south;
         this.east = east;
+
+        this.latLng = new LatLng(latitude, longitude);
     }
 
     /**
@@ -44,6 +50,15 @@ public class Cluster<T extends ClusterItem> {
      */
     public double getLongitude() {
         return longitude;
+    }
+
+    /**
+     * The LatLng based on latitude and longitude.
+     *
+     * @return the latLng of the cluster
+     */
+    public LatLng getLatLng() {
+        return latLng;
     }
 
     /**

--- a/clustering/src/main/java/com/huawei/clustering/ClusterManager.java
+++ b/clustering/src/main/java/com/huawei/clustering/ClusterManager.java
@@ -95,6 +95,16 @@ public class ClusterManager<T extends ClusterItem> implements HuaweiMap.OnCamera
     }
 
     /**
+     * Sets a custom render post processor thus replacing the default one.
+     *
+     * @param renderPostProcessor the render post processor that's used for modifying the marker being rendered
+     */
+    public void setRenderPostProcessor(@NonNull RenderPostProcessor<T> renderPostProcessor) {
+        Preconditions.checkNotNull(renderPostProcessor);
+        mRenderer.setRenderPostProcessor(renderPostProcessor);
+    }
+
+    /**
      * Sets a callback that's invoked when a cluster or a cluster item is clicked.
      *
      * @param callbacks the callback that's invoked when a cluster or an individual item is clicked.

--- a/clustering/src/main/java/com/huawei/clustering/DefaultRenderPostProcessor.java
+++ b/clustering/src/main/java/com/huawei/clustering/DefaultRenderPostProcessor.java
@@ -3,10 +3,16 @@ package com.huawei.clustering;
 
 import com.huawei.hms.maps.model.Marker;
 
-public class DefaultRenderPostProcessor<T extends ClusterItem> implements RenderPostProcessor<T> {
+import androidx.annotation.NonNull;
 
+/**
+ * A default render post processor that does nothing.
+ *
+ * @param <T> type of the the cluster item
+ */
+public class DefaultRenderPostProcessor<T extends ClusterItem> implements RenderPostProcessor<T> {
     @Override
-    public boolean postProcess(Marker marker, Cluster<T> cluster) {
-        return false;
+    public void postProcess(@NonNull Marker marker, @NonNull Cluster<T> cluster) {
+        // do nothing by default
     }
 }

--- a/clustering/src/main/java/com/huawei/clustering/RenderPostProcessor.java
+++ b/clustering/src/main/java/com/huawei/clustering/RenderPostProcessor.java
@@ -4,7 +4,17 @@ import androidx.annotation.NonNull;
 
 import com.huawei.hms.maps.model.Marker;
 
+/**
+ * Allows for modifying the marker that is being rendered.
+ *
+ * @param <T> type of the cluster item
+ */
 public interface RenderPostProcessor<T extends ClusterItem> {
-
-    boolean postProcess(@NonNull Marker marker, @NonNull Cluster<T> cluster);
+    /**
+     * Allows for modifying the marker that is being rendered.
+     *
+     * @param marker the marker
+     * @param cluster the cluster
+     */
+    void postProcess(@NonNull Marker marker, @NonNull Cluster<T> cluster);
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name='ClusterDemo'
-include ':singleCluster', 'multipleClusters', ':clusterings'
+include ':singleCluster', 'multipleClusters'
 include ':clustering'


### PR DESCRIPTION
The RenderPostProcessor was not actually bound to be usable, but I needed it at work.

I figured I could provide the changes I've made "downstream" (upstream? I never know which one is which).

So now, RenderPostProcessor is called, and I made some very small changes to reduce the number of object allocations.